### PR TITLE
WooCommerce Subscriptions 2.0 feature support

### DIFF
--- a/classes/class-wc-gateway-securesubmit-subscriptions-deprecated.php
+++ b/classes/class-wc-gateway-securesubmit-subscriptions-deprecated.php
@@ -1,0 +1,88 @@
+<?php
+
+class WC_Gateway_SecureSubmit_Subscriptions_Deprecated extends WC_Gateway_SecureSubmit_Subscriptions
+{
+    public function init()
+    {
+        if (class_exists('WC_Subscriptions_Order')) {
+            add_action('scheduled_subscription_payment_' . $this->id, array($this, 'scheduledSubscriptionPayment'), 10, 3);
+            add_action('woocommerce_subscriptions_changed_failing_payment_method_' . $this->id, array($this, 'updateFailingPaymentMethod'), 10, 3);
+            add_filter('woocommerce_subscriptions_renewal_order_meta_query', array($this, 'removeRenewalOrderMeta'), 10, 4);
+            add_filter('woocommerce_my_subscriptions_recurring_payment_method', array($this, 'maybeRenderSubscriptionPaymentMethod'), 10, 3);
+        }
+    }
+
+    protected function orderHasSubscription($order)
+    {
+        if (function_exists('wcs_order_contains_subscription')) {
+            return wcs_order_contains_subscription($order);
+        }
+        return WC_Subscriptions_Order::order_contains_subscription($order);
+    }
+
+    public function processSubscription($orderId)
+    {
+        $result = parent::processSubscription($orderId);
+        $order = new WC_Order($orderId);
+        $order->payment_complete();
+        WC_Subscriptions_Manager::activate_subscriptions_for_order($order);
+        return $result;
+    }
+
+    public function scheduledSubscriptionPayment($amount, $order, $productId = null)
+    {
+        $result = $this->processSubscriptionPayment($order, $amount);
+
+        if (is_wp_error($result)) {
+            WC_Subscriptions_Manager::process_subscription_payment_failure_on_order($order, $productId);
+        } else {
+            WC_Subscriptions_Manager::process_subscription_payments_on_order($order);
+        }
+    }
+
+    public function updateFailingPaymentMethod($old, $new, $subscriptionKey = null)
+    {
+        update_post_meta($old->id, '_securesubmit_card_token', get_post_meta($new->id, '_securesubmit_card_token', true));
+    }
+
+    public function removeRenewalOrderMeta($orderMetaQuery, $originalOrderId, $renewalOrderId, $newOrderRole)
+    {
+        if ('parent' == $newOrderRole) {
+            $orderMetaQuery .= " AND `meta_key` <> '_securesubmit_card_token' ";
+        }
+        return $orderMetaQuery;
+    }
+
+    public function maybeRenderSubscriptionPaymentMethod($paymentMethodToDisplay, $subscriptionDetails, WC_Order $order)
+    {
+        if ($this->id !== $order->recurring_payment_method || !$order->customer_user) {
+            return $paymentMethodToDisplay;
+        }
+
+        $userId = $order->customer_user;
+        $token  = get_post_meta($order->id, '_securesubmit_card_token', true);
+        $cards  = get_user_meta($userId, '_secure_submit_card', false);
+
+        if ($cards) {
+            $foundCard = false;
+            foreach ($cards as $card) {
+                if ($card['token_value'] === $token) {
+                    $foundCard              = true;
+                    $paymentMethodToDisplay = sprintf(__('Via %s card ending in %s', 'hps-securesubmit'), $card['card_type'], $card['last_four']);
+                    break;
+                }
+            }
+            if (!$foundCard) {
+                $paymentMethodToDisplay = sprintf(__('Via %s card ending in %s', 'hps-securesubmit'), $card[0]['card_type'], $card[0]['last_four']);
+            }
+        }
+
+        return $paymentMethodToDisplay;
+    }
+
+    protected function saveTokenMeta($order, $token)
+    {
+        add_post_meta($order->id, '_securesubmit_card_token', $token, true);
+    }
+}
+new WC_Gateway_SecureSubmit_Subscriptions();

--- a/classes/class-wc-gateway-securesubmit-subscriptions.php
+++ b/classes/class-wc-gateway-securesubmit-subscriptions.php
@@ -37,7 +37,6 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
 
     public function process_payment($orderId)
     {
-      error_log('process_payment ' . $orderId);
         if (class_exists('WC_Subscriptions_Order') && $this->orderHasSubscription($orderId)) {
             return $this->processSubscription($orderId);
         } else {
@@ -60,7 +59,6 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
 
     public function processSubscription($orderId)
     {
-      error_log('processSubscription ' . $orderId);
         global $woocommerce;
 
         $order = new WC_Order($orderId);
@@ -132,7 +130,7 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
                 }
 
                 if ($saveToOrder) {
-                  $this->saveTokenMeta($order, $tokenval);
+                    $this->saveTokenMeta($order, $tokenval);
                 }
 
                 $woocommerce->cart->empty_cart();
@@ -166,7 +164,11 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
 
     public function scheduledSubscriptionPayment($amount, $order, $productId = null)
     {
-      error_log('scheduledSubscriptionPayment ' . $order->id);
+        // TODO: why is this necessary to prevent double authorization?
+        if ($order->post_status !== 'wc-pending') {
+            return;
+        }
+
         $result = $this->processSubscriptionPayment($order, $amount);
 
         if (is_wp_error($result)) {
@@ -181,7 +183,6 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
         if (!is_object($order)) {
             $order = new WC_Order($order);
         }
-      error_log('processSubscriptionPayment ' . $order->id);
         $tokenValue = get_post_meta($order->id, '_securesubmit_card_token', true);
         $token = new HpsTokenData();
         $token->tokenValue = $tokenValue;
@@ -226,7 +227,7 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
                 ($amount == 0 ? 'verify' : 'payment'),
                 $response->transactionId
             ));
-            // add_post_meta($order->id, '_transaction_id', $response->transactionId, true);
+            add_post_meta($order->id, '_transaction_id', $response->transactionId, true);
 
             return $response;
         } catch (Exception $e) {

--- a/classes/class-wc-gateway-securesubmit.php
+++ b/classes/class-wc-gateway-securesubmit.php
@@ -34,7 +34,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway
         $this->use_iframes          = ($this->getSetting('use_iframes') == 'yes' ? true : false);
         $this->supports             = array(
                                         'products',
-                                        'refunds',
+                                        'refunds'
                                      );
 
         add_action('wp_enqueue_scripts', array($this, 'payment_scripts'));
@@ -324,7 +324,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway
                 }
 
                 $order->add_order_note(__('SecureSubmit payment completed', 'hps-securesubmit') . ' (Transaction ID: ' . $response->transactionId . ')');
-                $order->payment_complete();
+                $order->payment_complete($response->transactionId);
                 $woocommerce->cart->empty_cart();
 
                 return array(

--- a/classes/includes/src/Services/Gateway/HpsCentinelGatewayService.php
+++ b/classes/includes/src/Services/Gateway/HpsCentinelGatewayService.php
@@ -28,14 +28,14 @@ class HpsCentinelGatewayService
             'Accept: text/xml',
             'Content-length: '.strlen($data),
         );
-        error_log($xmlData);
+        // error_log($xmlData);
 
         return $this->submitRequest($url, $header, $data);
     }
 
     public function processResponse($curlResponse, $curlInfo, $curlError)
     {
-        error_log($curlResponse);
+        // error_log($curlResponse);
         switch ($curlInfo['http_code']) {
             case '200':
                 return simplexml_load_string($curlResponse);

--- a/classes/wc-gateway-securesubmit-masterpass/class-payment.php
+++ b/classes/wc-gateway-securesubmit-masterpass/class-payment.php
@@ -59,7 +59,7 @@ class WC_Gateway_SecureSubmit_MasterPass_Payment
             }
 
             $order->add_order_note(__('MasterPass payment completed', 'wc_securesubmit') . ' (Transaction ID: ' . $transactionId . ')');
-            $order->payment_complete();
+            $order->payment_complete($transactionId);
             $cart->empty_cart();
 
             update_post_meta($order->id, '_transaction_id', $transactionId);

--- a/gateway-securesubmit.php
+++ b/gateway-securesubmit.php
@@ -65,7 +65,11 @@ class WooCommerceSecureSubmitGateway
     {
         $methods[] = self::SECURESUBMIT_GATEWAY_CLASS . '_MasterPass';
         if (class_exists('WC_Subscriptions_Order')) {
-            $methods[] = self::SECURESUBMIT_GATEWAY_CLASS . '_Subscriptions';
+            $klass = self::SECURESUBMIT_GATEWAY_CLASS . '_Subscriptions';
+            if (!function_exists('wcs_create_renewal_order')) {
+                $klass .= '_Deprecated';
+            }
+            $methods[] = $klass;
         } else {
             $methods[] = self::SECURESUBMIT_GATEWAY_CLASS;
         }
@@ -100,6 +104,7 @@ class WooCommerceSecureSubmitGateway
     {
         include_once('classes/class-wc-gateway-securesubmit.php');
         include_once('classes/class-wc-gateway-securesubmit-subscriptions.php');
+        include_once('classes/class-wc-gateway-securesubmit-subscriptions-deprecated.php');
         include_once('classes/class-wc-gateway-securesubmit-masterpass.php');
     }
 }


### PR DESCRIPTION
Support the new 2.0 changes:

- Remaining deprecated hooks have been changed
- Support for multiple subscriptions
- Support for admin payment method changes
- Use renewal orders for processing renewal payments
- New location for order metas

Integrations using WooCommerce Subscriptions versions < 2.0 will end up using the `WC_Gateway_SecureSubmit_Subscriptions_Deprecated` class which still uses the old hooks, processes renewals in the old way, etc. This follows the Simplify Commerce upgrade to fully support 2.0 documented in the [upgrade documentation for payment gateways](https://docs.woothemes.com/document/subscriptions/develop/payment-gateway-integration/upgrade-guide-for-subscriptions-v2-0/).