### PR TITLE
Updates payment method ID & enable/disable default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Download the contents and extract to your WordPress plugin folder. Activate.
 
 Changelog
 ------------
+####1.7.2
+* Bug Fix - Resolves WooCommerce PayPal collision
+* Improvement - Sets Heartland PayPal enabled flag to false for new installs
+
 ####1.7.1
 * Bug Fix
 

--- a/classes/class-wc-gateway-securesubmit-paypal.php
+++ b/classes/class-wc-gateway-securesubmit-paypal.php
@@ -3,7 +3,6 @@
 Plugin Name: WooCommerce Heartland PayPal Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland PayPal Payment gateway for WooCommerce.
-Version: 1.0.0
 Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */

--- a/classes/class-wc-gateway-securesubmit-paypal.php
+++ b/classes/class-wc-gateway-securesubmit-paypal.php
@@ -24,7 +24,7 @@ class WC_Gateway_SecureSubmit_PayPal extends WC_Payment_Gateway {
      * Constructor for the gateway.
      */
     public function __construct() {
-        $this->id                 = 'paypal';
+        $this->id                 = 'heartland_paypal';
         $this->has_fields         = false;
         $this->order_button_text  = __( 'Proceed to PayPal', 'wc_securesubmit' );
         $this->method_title       = __( 'Heartland Paypal', 'wc_securesubmit' );

--- a/classes/includes/settings-paypal.php
+++ b/classes/includes/settings-paypal.php
@@ -11,8 +11,8 @@ return array(
 	'enabled' => array(
 		'title'   => __( 'Enable/Disable', 'wc_securesubmit' ),
 		'type'    => 'checkbox',
-		'label'   => __( 'Enable PayPal Secure Submit', 'wc_securesubmit' ),
-		'default' => 'yes'
+		'label'   => __( 'Enable Heartland PayPal', 'wc_securesubmit' ),
+		'default' => 'no'
 	),
 	'title' => array(
 		'title'       => __( 'Title', 'wc_securesubmit' ),

--- a/gateway-securesubmit.php
+++ b/gateway-securesubmit.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce SecureSubmit Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland Payment Systems gateway for WooCommerce.
-Version: 1.7.1
+Version: 1.7.2
 Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,10 @@ Get your Certification (Dev/Sandbox) Api Keys by creating an account on https://
 3. A view of the Manage Cards section.
 
 == Changelog ==
+= 1.7.2 =
+* Bug Fix - Resolves WooCommerce PayPal collision
+* Improvement - Sets Heartland PayPal enabled flag to false for new installs
+
 = 1.7.1 =
 * Bug Fix
 


### PR DESCRIPTION
Resolves an issue with method id collision with WooCommerce builtin
Paypal. Sets Heartland PayPal setting to disabled for new installs.