### PR TITLE
update order_credit_card_details hook

### DIFF
--- a/classes/wc-gateway-securesubmit/class-payment.php
+++ b/classes/wc-gateway-securesubmit/class-payment.php
@@ -162,8 +162,8 @@ class WC_Gateway_SecureSubmit_Payment
                       ? 'captured'
                       : 'authorized';
                 $order->add_order_note(__('SecureSubmit payment ' . $verb .($authenticated ? ' and authenticated' : ''), 'wc_securesubmit') . ' (Transaction ID: ' . $response->transactionId . ')');
+                do_action('wc_securesubmit_order_credit_card_details', $orderId, $card_type, $last_four);
                 $order->payment_complete($response->transactionId);
-		do_action('wc_securesubmit_order_credit_card_details', $orderId, $card_type, $last_four);
                 WC()->cart->empty_cart();
 
                 return array(


### PR DESCRIPTION
Changes execution order of `wc_securesubmit_order_credit_card_details` hook to be called before the order is marked as complete. This ensures an order email has this data available to it if the integrator chooses to do so