### PR TITLE
fix util class's getData method on woo 2.6

### DIFF
--- a/classes/class-util.php
+++ b/classes/class-util.php
@@ -19,7 +19,7 @@ class WC_SecureSubmit_Util
             return $object->{$method}();
         }
 
-        if (property_exists($object, $property)) {
+        if (property_exists($object, $property) || isset($object->{$property})) {
             return $object->{$property};
         }
 


### PR DESCRIPTION
WooCommerce 2.6 is using some magic properties (`__get`/`__set`) for some of the data, so an `isset` check is required beyond the call to `property_exists`