### PR TITLE
Disable gift cards when users want to change payment type of existing…

### DIFF
--- a/classes/class-wc-gateway-securesubmit-giftcards.php
+++ b/classes/class-wc-gateway-securesubmit-giftcards.php
@@ -393,16 +393,16 @@ class WC_Gateway_SecureSubmit_GiftCards extends WC_Gateway_SecureSubmit {
     }
 
     public function giftCardsAllowed() {
-
+        
         $subscriptions_active = $this->subscriptionsActive();
 
         if ( $subscriptions_active ) {
-
+            
             if ( !empty($_GET['change_payment_method']) ) {
 
-                $product = get_post($_GET['change_payment_method']);
+                $subscription = new WC_Subscription($_GET['change_payment_method']);
 
-                if ( FALSE !== strpos( $product->post_type, 'subscription') ) {
+                if ( !empty($subscription) ) {
 
                     return FALSE;
 

--- a/classes/class-wc-gateway-securesubmit-giftcards.php
+++ b/classes/class-wc-gateway-securesubmit-giftcards.php
@@ -11,8 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  - Gift Card has zero balance
  */
 
-class WC_Gateway_SecureSubmit_GiftCards
-    extends WC_Gateway_SecureSubmit {
+class WC_Gateway_SecureSubmit_GiftCards extends WC_Gateway_SecureSubmit {
 
     protected $gift_card               = NULL;
     protected $gift_card_submitted     = NULL;
@@ -399,7 +398,21 @@ class WC_Gateway_SecureSubmit_GiftCards
 
         if ( $subscriptions_active ) {
 
-            return ( $this->cartHasSubscriptionProducts() ) ? FALSE : TRUE;
+            if ( !empty($_GET['change_payment_method']) ) {
+
+                $product = get_post($_GET['change_payment_method']);
+
+                if ( FALSE !== strpos( $product->post_type, 'subscription') ) {
+
+                    return FALSE;
+
+                }
+
+            } else {
+
+                return ( $this->cartHasSubscriptionProducts() ) ? FALSE : TRUE;
+
+            }
 
         }
 

--- a/classes/class-wc-gateway-securesubmit-giftcards.php
+++ b/classes/class-wc-gateway-securesubmit-giftcards.php
@@ -401,8 +401,7 @@ class WC_Gateway_SecureSubmit_GiftCards extends WC_Gateway_SecureSubmit {
             if ( !empty($_GET['change_payment_method']) ) {
 
                 $subscription = new WC_Subscription($_GET['change_payment_method']);
-
-                if ( !empty($subscription) ) {
+                if ( !empty($subscription) && (FALSE !== strpos($subscription->order_type, 'subscription')) ) {
 
                     return FALSE;
 


### PR DESCRIPTION
When a user wants to change the payment type of an existing subscriptions, Gift Cards should be disabled.