### PR TITLE
Feature/dynamic descriptor

### DIFF
--- a/classes/class-wc-gateway-securesubmit.php
+++ b/classes/class-wc-gateway-securesubmit.php
@@ -31,6 +31,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway
         $this->public_key              = $this->getSetting('public_key');
         $this->custom_error            = $this->getSetting('custom_error');
         $this->paymentaction           = $this->getSetting('paymentaction');
+        $this->dynamic_descriptor      = $this->getSetting('dynamic_descriptor');
         $this->enable_anti_fraud       = ($this->getSetting('enable_anti_fraud') == 'yes' ? true : false);
         $this->allow_fraud             = $this->getSetting('allow_fraud');
         $this->email_fraud             = $this->getSetting('email_fraud');

--- a/classes/class-wc-gateway-securesubmit.php
+++ b/classes/class-wc-gateway-securesubmit.php
@@ -31,7 +31,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway
         $this->public_key              = $this->getSetting('public_key');
         $this->custom_error            = $this->getSetting('custom_error');
         $this->paymentaction           = $this->getSetting('paymentaction');
-        $this->dynamic_descriptor      = $this->getSetting('dynamic_descriptor');
+        $this->txndescriptor           = $this->getSetting('txndescriptor');
         $this->enable_anti_fraud       = ($this->getSetting('enable_anti_fraud') == 'yes' ? true : false);
         $this->allow_fraud             = $this->getSetting('allow_fraud');
         $this->email_fraud             = $this->getSetting('email_fraud');

--- a/classes/wc-gateway-securesubmit/class-capture.php
+++ b/classes/wc-gateway-securesubmit/class-capture.php
@@ -32,7 +32,6 @@ class WC_Gateway_SecureSubmit_Capture
             try {
                 $response = $chargeService->capture()
                     ->withTransactionId($transactionId)
-                    ->withTxnDescriptor($this->parent->txndescriptor)
                     ->withAmount(wc_format_decimal($order->get_total() - $order->get_total_refunded(), 2))
                     ->execute();
                 $order->add_order_note(__('SecureSubmit payment captured', 'wc_securesubmit') . ' (Transaction ID: ' . $response->transactionId . ')');

--- a/classes/wc-gateway-securesubmit/class-capture.php
+++ b/classes/wc-gateway-securesubmit/class-capture.php
@@ -32,6 +32,7 @@ class WC_Gateway_SecureSubmit_Capture
             try {
                 $response = $chargeService->capture()
                     ->withTransactionId($transactionId)
+                    ->withTxnDescriptor($this->parent->txndescriptor)
                     ->withAmount(wc_format_decimal($order->get_total() - $order->get_total_refunded(), 2))
                     ->execute();
                 $order->add_order_note(__('SecureSubmit payment captured', 'wc_securesubmit') . ' (Transaction ID: ' . $response->transactionId . ')');

--- a/classes/wc-gateway-securesubmit/class-payment.php
+++ b/classes/wc-gateway-securesubmit/class-payment.php
@@ -128,6 +128,7 @@ class WC_Gateway_SecureSubmit_Payment
                     ->withDetails($details)
                     ->withSecureEcommerce($secureEcommerce)
                     ->withAllowDuplicates(true)
+                    ->withTxnDescriptor($this->parent->txndescriptor)
                     ->execute();
 
                 if ($save_card_to_customer) {

--- a/etc/securesubmit-options.php
+++ b/etc/securesubmit-options.php
@@ -115,6 +115,10 @@ return array(
         'type'        => 'text',
         'description' => __('During any Capture or Authorize call, this value will be passed along in the Dynamic Descriptor field.', 'wc_securesubmit'),
         'default'     => __('', 'wc_securesubmit'),
+        'class'       => 'txndescriptor',
+        'custom_attributes' => array(
+            'maxlength' => 18,
+        ),
     ),
     'use_iframes' => array(
         'title'       => __('Use iFrames', 'wc_securesubmit'),

--- a/etc/securesubmit-options.php
+++ b/etc/securesubmit-options.php
@@ -110,6 +110,12 @@ return array(
             'authorization' => __('Authorize', 'wc_securesubmit'),
         ),
     ),
+    'dynamic_descriptor' => array(
+        'title'       => __('Dynamic Descriptor', 'wc_securesubmit'),
+        'type'        => 'text',
+        'description' => __('During any Capture or Authorize call, if this box has a value, pass it along in the Dynamic Descriptor field.', 'wc_securesubmit'),
+        'default'     => __('', 'wc_securesubmit'),
+    ),
     'use_iframes' => array(
         'title'       => __('Use iFrames', 'wc_securesubmit'),
         'label'       => __('Host the payment fields on Heartland\'s servers', 'wc_securesubmit'),

--- a/etc/securesubmit-options.php
+++ b/etc/securesubmit-options.php
@@ -113,7 +113,7 @@ return array(
     'txndescriptor' => array(
         'title'       => __('Order Transaction Descriptor', 'wc_securesubmit'),
         'type'        => 'text',
-        'description' => __('During any Capture or Authorize call, this value will be passed along in the Dynamic Descriptor field.', 'wc_securesubmit'),
+        'description' => __('During a Capture or Authorize payment action, this value will be passed along as the TxnDescriptor. Please contact <a href="mailto:securesubmitcert@e-hps.com?Subject=WooCommerce%20SecureSubmit%20TxnDescriptor Option">securesubmitcert@e-hps.com</a> with any question regarding this option.', 'wc_securesubmit'),
         'default'     => __('', 'wc_securesubmit'),
         'class'       => 'txndescriptor',
         'custom_attributes' => array(

--- a/etc/securesubmit-options.php
+++ b/etc/securesubmit-options.php
@@ -110,10 +110,10 @@ return array(
             'authorization' => __('Authorize', 'wc_securesubmit'),
         ),
     ),
-    'dynamic_descriptor' => array(
-        'title'       => __('Dynamic Descriptor', 'wc_securesubmit'),
+    'txndescriptor' => array(
+        'title'       => __('Order Transaction Descriptor', 'wc_securesubmit'),
         'type'        => 'text',
-        'description' => __('During any Capture or Authorize call, if this box has a value, pass it along in the Dynamic Descriptor field.', 'wc_securesubmit'),
+        'description' => __('During any Capture or Authorize call, this value will be passed along in the Dynamic Descriptor field.', 'wc_securesubmit'),
         'default'     => __('', 'wc_securesubmit'),
     ),
     'use_iframes' => array(


### PR DESCRIPTION
Added a new field to the SecureSubmit options page. This option, when defined, will be passed with Charge and Auth transactions as the _TxnDescriptor_. There is a constraint of 18 characters.