### PR TITLE
Updated version to 1.11.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Download the contents and extract to your WordPress plugin folder. Activate.
 
 Changelog
 ------------
+#### 1.11.13
+* Fix issue with subscriptions. When there is a change payment, the existing post meta record needs to be updated with the new token.
+* Fix issue with Avatax extension. The shipping tax was being subtracted from the subtotal incorrectly.
+* Pass order id with PayPal transactions.
+
 #### 1.11.12
 * Fix issue with payment updates. Prevent payment method update from charging.
 * Add new setting to SecureSubmit that will pass a value as the TxnDescriptor.

--- a/gateway-securesubmit.php
+++ b/gateway-securesubmit.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce SecureSubmit Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland Payment Systems gateway for WooCommerce.
-Version: 1.11.12
+Version: 1.11.13
 Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,11 @@ Get your Certification (Dev/Sandbox) Api Keys by creating an account on https://
 3. A view of the Manage Cards section
 
 == Changelog ==
+= 1.11.13 =
+* Fix issue with subscriptions. When there is a change payment, the existing post meta record needs to be updated with the new token.
+* Fix issue with Avatax extension. The shipping tax was being subtracted from the subtotal incorrectly.
+* Pass order id with PayPal transactions.
+
 = 1.11.12 =
 * Fix issue with payment updates. Prevent payment method update from charging.
 * Add new setting to SecureSubmit that will pass a value as the TxnDescriptor.


### PR DESCRIPTION
### 1.11.13
* Fix issue with subscriptions. When there is a change payment, the existing post meta record needs to be updated with the new token.
* Fix issue with Avatax extension. The shipping tax was being subtracted from the subtotal incorrectly.
* Pass order id with PayPal transactions.