### PR TITLE
added add_order_note to display payment errors in subscription notes

### DIFF
--- a/classes/class-wc-gateway-securesubmit-subscriptions.php
+++ b/classes/class-wc-gateway-securesubmit-subscriptions.php
@@ -281,6 +281,9 @@ class WC_Gateway_SecureSubmit_Subscriptions extends WC_Gateway_SecureSubmit
 
             return $response;
         } catch (Exception $e) {
+            // adds a private note to make it easier for an admin user to see why the payment failed.
+            $order->add_order_note(sprintf(__('SecureSubmit payment error: %s', 'wc_securesubmit'), (string)$e->getMessage()));
+
             return new WP_Error('securesubmit_error', sprintf(__('SecureSubmit payment error: %s', 'wc_securesubmit'), (string)$e->getMessage()));
         }
     }


### PR DESCRIPTION
As a woocommcerce admin user, I want to be able to view subscription payment errors in the notes for a given subscription, so that I can easily understand what error my customer sees and cut down on time spent troubleshooting.