### PR TITLE
Check if the cards array is empty before showing button

### DIFF
--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -20,7 +20,7 @@
         <div class="securesubmit-content">
             <!-- Start LOGGED IN SAVED CARDS -->
             <?php $cards = get_user_meta(get_current_user_id(), '_secure_submit_card', false); ?>
-            <?php if (is_user_logged_in() && isset($cards)): ?>
+            <?php if (is_user_logged_in() && isset($cards) && !empty($cards)): ?>
                 <div class="saved-creditcards-list-header saved-creditcards-list form-row form-row-wide no-bottom-margin">
                     <div class="ss-section-header clearfix">
                         <h6>Select Payment Method</h6>

--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -20,7 +20,7 @@
         <div class="securesubmit-content">
             <!-- Start LOGGED IN SAVED CARDS -->
             <?php $cards = get_user_meta(get_current_user_id(), '_secure_submit_card', false); ?>
-            <?php if (is_user_logged_in() && isset($cards) && !empty($cards)): ?>
+            <?php if (is_user_logged_in() && !empty($cards)): ?>
                 <div class="saved-creditcards-list-header saved-creditcards-list form-row form-row-wide no-bottom-margin">
                     <div class="ss-section-header clearfix">
                         <h6>Select Payment Method</h6>


### PR DESCRIPTION
The `$cards` variable can be set but still be an empty array. In that case, the logged in user is still shown the Manage Cards button even if they have no cards to manage.

This adds a check to make sure that `$cards` isn't empty (thus, at least one card exists) before showing the Manage Cards button.