### PR TITLE
Hide Apply gift card button if gift card has not been entered

### DIFF
--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -143,12 +143,25 @@ if ($this->allow_gift_cards && $gift_cards_allowed) : // Allow customers to pay 
                             <p id="gift-card-error"></p>
                             <p id="gift-card-success"></p>
                       </div>
-                      <button id="apply-gift-card" class="button"><?php _e('Apply', 'wc_securesubmit'); ?></button>
+                      <button id="apply-gift-card" class="button" style="visibility:hidden"><?php _e('Apply', 'wc_securesubmit'); ?></button>
                       <script data-cfasync="false">
                           jQuery("#apply-gift-card").on('click', function (event) {
                               event.preventDefault();
                               window.applyGiftCard();
                           });
+                          jQuery("#gift-card-number").on('keyup', function (event) {
+                            checkEnableGiftCardApplyButton();
+                          });
+                          jQuery("#gift-card-pin").on('keyup', function (event) {
+                            checkEnableGiftCardApplyButton();
+                          });
+                          function checkEnableGiftCardApplyButton() {
+                            if (jQuery("#gift-card-number").val().length >= 16 && jQuery("#gift-card-pin").val().length >= 4) {
+                                jQuery("#apply-gift-card").css("visibility", "visible");
+                            } else {
+                                jQuery("#apply-gift-card").css("visibility", "hidden");
+                            }
+                          }
                       </script>
                 </div>
                 <div class="clear"></div>

--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -156,7 +156,7 @@ if ($this->allow_gift_cards && $gift_cards_allowed) : // Allow customers to pay 
                             checkEnableGiftCardApplyButton();
                           });
                           function checkEnableGiftCardApplyButton() {
-                            if (jQuery("#gift-card-number").val().length >= 16 && jQuery("#gift-card-pin").val().length >= 4) {
+                            if (jQuery("#gift-card-number").val().length === 19 && jQuery("#gift-card-pin").val().length === 4) {
                                 jQuery("#apply-gift-card").css("visibility", "visible");
                             } else {
                                 jQuery("#apply-gift-card").css("visibility", "hidden");


### PR DESCRIPTION
We have having issues where a customer is intending to pay with a credit card, but not a gift card. They enter in their credit card details and see the 'Apply' button below and click it, thinking they need to apply their credit card number before they place the order as is a common flow on many e-commerce sites. Then they get confused when nothing happens.

This change sets the default visibility of the apply button to hidden. (It doesn't use the display property so that the button will still take up space in the DOM.) Then it applies listeners on the gift card number and pin fields. If the gift card number field is 16 digits or more and the pin field is four digits or more then the apply button is made visible.

I'm uncertain of your valid gift card number ranges so the check of `16` may not be the most appropriate. Likewise, `keyup` may or may not be the most appropriate event to hook into, though I haven't uncovered any issues yet.

I also think the button should have a label of `Apply gift card` instead of just `Apply`, but I'm doing this through a plugin that modifies the translation with the `gettext` filter. I'm also filtering the `Use a gift card` string to be `Use a Acme Company gift card` because customers were trying to use things like a Visa Gift Card in those fields.