### PR TITLE
Improve responsive design for gift cards

### DIFF
--- a/assets/css/securesubmit.css
+++ b/assets/css/securesubmit.css
@@ -743,36 +743,18 @@ html body .woocommerce .payment_method_securesubmit iframe{
 
 /* GIFT CARDS */
 #gift-card-row#gift-card-row {
-    display: table;
     margin: 1em 0 0;
     padding-top: 1.5em;
     border-top: 2px solid #DDD;
 }
 
 #gift-card-label {
-    display: table-row;
     text-transform: uppercase;
     font-size: 13px;
     letter-spacing: 1px;
-    white-space: nowrap;
 }
 
 #gift-card-input {
-    display: table-cell;
     position: relative;
     width: 100%;
-}
-
-#apply-gift-card {
-    display: table-cell;
-    white-space: nowrap;
-    margin-left: 1em;
-}
-
-#gift-card-number {
-    width: 70%;
-}
-
-#gift-card-pin {
-    width: 26%;
 }

--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -129,39 +129,47 @@
 
 <?php
 $gift_cards = new WC_Gateway_SecureSubmit_GiftCards();
-$gift_cards_allowed = $gift_cards->giftCardsAllowed();
+    $gift_cards_allowed = $gift_cards->giftCardsAllowed();
 
-if ($this->allow_gift_cards && $gift_cards_allowed) : // Allow customers to pay with Heartland gift cards ?>
+    if ($this->allow_gift_cards && $gift_cards_allowed) : // Allow customers to pay with Heartland gift cards?>
     <fieldset>
-          <!-- Start Gift Card -->
-          <div class="securesubmit-content gift-card-content">
-                <div class="form-row form-row-wide" id="gift-card-row">
-                      <label id="gift-card-label" for="gift-card-number"><?php _e('Use a gift card', 'wc_securesubmit'); ?></label>
-                      <div id="gift-card-input">
-                            <input type="tel" placeholder="Gift card" id="gift-card-number" value="" class="input-text">
-                            <input type="tel" placeholder="PIN" id="gift-card-pin" value="" class="input-text">
-                            <p id="gift-card-error"></p>
-                            <p id="gift-card-success"></p>
-                      </div>
-                      <button id="apply-gift-card" class="button"><?php _e('Apply', 'wc_securesubmit'); ?></button>
-                      <script data-cfasync="false">
-                          jQuery("#apply-gift-card").on('click', function (event) {
-                              event.preventDefault();
-                              window.applyGiftCard();
-                          });
-                      </script>
+        <!-- Start Gift Card -->
+        <div class="securesubmit-content gift-card-content">
+            <div class="form-row form-row-wide" id="gift-card-row">
+                <label id="gift-card-label" for="gift-card-number"><?php _e('Use a gift card', 'wc_securesubmit'); ?></label>
+            </div>
+            <div id="gift-card-input" class="form-row form-row-wide">
+                <div class="form-row-first half-row">
+                    <label for="gift-card-number"><?php _e('Gift card number', 'wc_securesubmit'); ?></label>
+                    <input type="tel" placeholder="Gift card" id="gift-card-number" value="" class="input-text">
                 </div>
-                <div class="clear"></div>
-          </div>
-          <!-- End Gift Card -->
+                <div class="form-row-last half-row">
+                    <label for="gift-card-pin"><?php _e('Gift card PIN', 'wc_securesubmit'); ?></label>
+                    <input type="tel" placeholder="PIN" id="gift-card-pin" value="" class="input-text">
+                </div>
+            </div>
+            <p id="gift-card-error"></p>
+            <p id="gift-card-success"></p>
+            <div class="form-row form-row-wide">
+                <button id="apply-gift-card" class="button"><?php _e('Apply', 'wc_securesubmit'); ?></button>
+            <div>
+            <script data-cfasync="false">
+                jQuery("#apply-gift-card").on('click', function (event) {
+                    event.preventDefault();
+                    window.applyGiftCard();
+                });
+            </script>
+        </div>
+        <div class="clear"></div>
+        <!-- End Gift Card -->
     </fieldset>
 <?php endif; ?>
 <script data-cfasync="false">
     window.securesubmitLoadIframes = window.securesubmitLoadIframes || function () {};
     window.securesubmitLoadIframes();
 </script>
-<?php // Attach the field event handlers when WC refreshes the payment fields ?>
-        
+<?php // Attach the field event handlers when WC refreshes the payment fields?>
+
 <script data-cfasync="false">
     window.securesubmitLoadEvents = window.securesubmitLoadEvents || function () {};
     window.securesubmitLoadEvents();

--- a/templates/payment-fields.php
+++ b/templates/payment-fields.php
@@ -135,7 +135,7 @@ $gift_cards = new WC_Gateway_SecureSubmit_GiftCards();
     <fieldset>
         <!-- Start Gift Card -->
         <div class="securesubmit-content gift-card-content">
-            <div class="form-row form-row-wide" id="gift-card-row">
+            <div class="clear" id="gift-card-row">
                 <label id="gift-card-label" for="gift-card-number"><?php _e('Use a gift card', 'wc_securesubmit'); ?></label>
             </div>
             <div id="gift-card-input" class="form-row form-row-wide">


### PR DESCRIPTION
This PR does not incorporate changes in https://github.com/hps/heartland-woocommerce-plugin/pull/207

In smaller browser widths, say 320x568 of the iPhone SE, the gift card number field would overflow the page and is difficult to see while entering. This changes the layout of the gift card number and PIN fields to use the responsive layout provided in WooCommerce just like the credit card number and expiration date fields above use.

Additionally, this PR adds labels to the gift card number and PIN fields to improve accessibility and provide a more consistent visual match with the credit card fields.